### PR TITLE
Implement defaults/property handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
 		"php": ">=5.4",
 		"symfony/yaml": "^3.3",
 		"symfony/console": "^3.3",
-		"symfony/event-dispatcher": "^3.3"
+		"symfony/event-dispatcher": "^3.3",
+		"twig/twig": "^1.35"
 	},
 	"bin": [
 		"bin/wasp"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "99e8df856b1aff1d2c93359291b396c0",
+    "content-hash": "012330b6ddb0a271b39b1350c3b2bd50",
     "packages": [
         {
             "name": "psr/log",
@@ -353,6 +353,71 @@
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
             "time": "2017-07-23T12:43:26+00:00"
+        },
+        {
+            "name": "twig/twig",
+            "version": "v1.35.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/Twig.git",
+                "reference": "daa657073e55b0a78cce8fdd22682fddecc6385f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/daa657073e55b0a78cce8fdd22682fddecc6385f",
+                "reference": "daa657073e55b0a78cce8fdd22682fddecc6385f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "psr/container": "^1.0",
+                "symfony/debug": "~2.7",
+                "symfony/phpunit-bridge": "~3.3@dev"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.35-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Twig_": "lib/"
+                },
+                "psr-4": {
+                    "Twig\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Armin Ronacher",
+                    "email": "armin.ronacher@active-4.com",
+                    "role": "Project Founder"
+                },
+                {
+                    "name": "Twig Team",
+                    "homepage": "http://twig.sensiolabs.org/contributors",
+                    "role": "Contributors"
+                }
+            ],
+            "description": "Twig, the flexible, fast, and secure template language for PHP",
+            "homepage": "http://twig.sensiolabs.org",
+            "keywords": [
+                "templating"
+            ],
+            "time": "2017-09-27T18:06:46+00:00"
         }
     ],
     "packages-dev": [],

--- a/src/Handler/AbstractHandler.php
+++ b/src/Handler/AbstractHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace OomphInc\WASP\Handler;
+
+abstract class AbstractHandler implements HandlerInterface {
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getSubscribedProperties() {
+		$classParts = explode('\\', static::class);
+		// take only class name (with no namespace) and convert from camel to snake case
+		return [strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', end($classParts)))];
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getIdentifier($property) {
+		return strtolower(str_replace('\\', '_', static::class));
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getDefaults($property) {
+		return null;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	abstract public function handle($transformer, $config, $property);
+
+}

--- a/src/Handler/DependentHandler.php
+++ b/src/Handler/DependentHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace OomphInc\WASP\Handler;
+
+use InvalidArgumentException;
+
+/**
+ * Handler that declares service dependencies.
+ */
+abstract class DependentHandler extends AbstractHandler {
+
+	public function __construct(array $services = []) {
+		$requested = static::getRequestedServices();
+		foreach ($services as $service => $obj) {
+			if (!in_array($service, $requested, true)) {
+				continue;
+			}
+
+			$this->$service = $obj;
+			$requested = array_diff($requested, [$service]);
+		}
+
+		// did we get all the requested services?
+		if (count($requested)) {
+			throw new InvalidArgumentException('Missing service(s): ' . implode(', ', $requested));
+		}
+	}
+
+	public static function getRequestedServices() {
+		return [];
+	}
+
+}

--- a/src/Handler/HandlerInterface.php
+++ b/src/Handler/HandlerInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace OomphInc\WASP\Handler;
+
+interface HandlerInterface {
+
+	/**
+	 * Get the properties that this handler is interested in.
+	 * @return array  top-level property name(s)
+	 */
+	public function getSubscribedProperties();
+
+	/**
+	 * Get the unique identifier for this handler.
+	 * @param  string $property top-level property that will be handled
+	 * @return string           unique identifier
+	 */
+	public function getIdentifier($property);
+
+	/**
+	 * Get the default values for the property.
+	 * @param  string $property top-level property
+	 * @return array|callable|null         array of defaults, callable for late default handling, or null for no defaults
+	 */
+	public function getDefaults($property);
+
+	/**
+	 * Handle the property.
+	 * @param YamlTransformer $transformer YAML transformer object
+	 * @param  array  $config  config for this property
+	 * @param  string $property  top-level property that is being handled
+	 */
+	public function handle($transformer, $config, $property);
+
+}

--- a/src/Handler/HandlerProxy.php
+++ b/src/Handler/HandlerProxy.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace OomphInc\WASP\Handler;
+
+use RuntimeException;
+
+/**
+ * Handler proxy allows a plugin to register many HandlerInterface objects
+ * that will only be instantiated if its respective property needs to be handled.
+ */
+class HandlerProxy implements HandlerInterface {
+
+	protected $classes = [];
+	protected $handlers = [];
+	protected $wasp;
+	protected $prefix;
+
+	public function __construct($wasp, $prefix) {
+		$this->wasp = $wasp;
+		$this->prefix = $prefix;
+	}
+
+	/**
+	 * Set a class name for a top-level property.
+	 * @param string $property top-level property
+	 * @param string $class    fully qualified class name
+	 */
+	public function setHandlerClass($property, $class) {
+		$this->classes[$property] = $class;
+	}
+
+	/**
+	 * Get the handler object for the given property, if available.
+	 * @param  string $property top-level property
+	 * @return HandlerInterface       handler object
+	 */
+	protected function getHandler($property) {
+		if (isset($this->handlers[$property])) {
+			return $this->handlers[$property];
+		} else if (isset($this->classes[$property])) {
+			// dependent handler?
+			if (is_callable([$this->classes[$property], 'getRequestedServices'])) {
+				// collect the handler's requested services
+				$services = [];
+				foreach (call_user_func([$this->classes[$property], 'getRequestedServices']) as $service) {
+					$services[$service] = $this->wasp->getService($service);
+				}
+				$handler = new $this->classes[$property]($services);
+			} else {
+				$handler = new $this->classes[$property];
+			}
+			return $this->handlers[$property] = $handler;
+		}
+		throw new RuntimeException("Handler for requested property '{$property}' is not registered!");
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getSubscribedProperties() {
+		return array_keys($this->classes);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getIdentifier($property) {
+		return $this->prefix . $property;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getDefaults($property) {
+		return $this->getHandler($property)->getDefaults($property);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function handle($transformer, $config, $property) {
+		$this->getHandler($property)->handle($transformer, $config, $property);
+	}
+
+}

--- a/src/Linter/PhpLinter.php
+++ b/src/Linter/PhpLinter.php
@@ -2,6 +2,8 @@
 
 namespace OomphInc\WASP\Linter;
 
+use RuntimeException;
+
 class PhpLinter implements LinterInterface {
 
 	public function lint($code) {

--- a/src/Property/PropertyChain.php
+++ b/src/Property/PropertyChain.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace OomphInc\WASP\Property;
+
+class PropertyChain {
+
+	protected $propertyTree;
+	protected $startingChain;
+	protected $chain;
+	protected $history = [];
+	protected $shortCircuitValues = [];
+	protected $ascendProp;
+
+	public function __construct($propertyTree, $chain = [], $ascendProp = null) {
+		$this->propertyTree = $propertyTree;
+		$this->startingChain = $this->chain = $chain;
+		$this->ascendProp = $ascendProp;
+	}
+
+	/**
+	 * Any offset can be accessed, but if it doesn't exist we just return null.
+	 */
+	public function __isset($offset) {
+		return true;
+	}
+
+	/**
+	 * Add to the property chain (or remove in the case of ascendProp being set).
+	 * @param  string $offset property name or value of ascendProp to go up a level
+	 * @return $this
+	 */
+	public function __get($offset) {
+		if (isset($this->ascendProp) && $offset === $this->ascendProp) {
+			array_pop($this->chain);
+		} else {
+			$this->chain[] = $offset;
+		}
+		return $this;
+	}
+
+	/**
+	 * Add to the chain and return the current value.
+	 * @param  string $method property name
+	 * @return mixed         value
+	 */
+	public function __call($method, $args) {
+		$this->__get($method);
+		return $this->getValue();
+	}
+
+	/**
+	 * Set a value to be returned for the given chain, short-circuiting the property tree.
+	 * @param array $chain property chain
+	 * @param mixed $value value to return
+	 */
+	public function setShortCircuitValue($chain, $value) {
+		$this->shortCircuitValues[serialize($chain)] = $value;
+	}
+
+	/**
+	 * Get the value at the current property chain and reset the chain.
+	 * @return mixed value
+	 */
+	public function getValue() {
+		$serializedChain = serialize($this->chain);
+		// check for value in short-circuit array, otherwise get from property tree
+		$value = isset($this->shortCircuitValues[$serializedChain])
+			? $this->shortCircuitValues[$serializedChain]
+			: $this->propertyTree->get($this->chain);
+		$this->resetChain();
+		return $value;
+	}
+
+	/**
+	 * Get the value at the current property chain as a string.
+	 * @return string value
+	 */
+	public function __toString() {
+		return (string) $this->getValue();
+	}
+
+	/**
+	 * Reset the chain back to the starting chain and add the current chain to the access history.
+	 */
+	protected function resetChain() {
+		$this->history[] = $this->chain;
+		$this->chain = $this->startingChain;
+	}
+
+	/**
+	 * Get the access history.
+	 * @return array  all chains that were accessed
+	 */
+	public function getHistory() {
+		return $this->history;
+	}
+
+}

--- a/src/Property/PropertyEnv.php
+++ b/src/Property/PropertyEnv.php
@@ -3,7 +3,7 @@
 namespace OomphInc\WASP\Property;
 
 /**
- * Simple object used to set and retrive values while processing twig templates.
+ * Simple object used to set and retrieve values while processing twig templates.
  */
 class PropertyEnv {
 

--- a/src/Property/PropertyEnv.php
+++ b/src/Property/PropertyEnv.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace OomphInc\WASP\Property;
+
+/**
+ * Simple object used to set and retrive values while processing twig templates.
+ */
+class PropertyEnv {
+
+	public function set($property, $value) {
+		$this->$property = $value;
+	}
+
+}

--- a/src/Property/PropertyOutput.php
+++ b/src/Property/PropertyOutput.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace OomphInc\WASP\Property;
+
+/**
+ * Used to override the rendered value of the template.
+ */
+class PropertyOutput {
+
+	protected $isOverriden = false;
+	protected $output;
+
+	/**
+	 * Override the template's rendered output value with the provided value.
+	 * @param  mixed $value override value
+	 */
+	public function setValue($value) {
+		$this->isOverriden = true;
+		$this->output = $value;
+	}
+
+	/**
+	 * Has the output been overridden?
+	 * @return boolean
+	 */
+	public function isOverridden() {
+		return $this->isOverriden;
+	}
+
+	/**
+	 * Get the overridden output value.
+	 * @return mixed
+	 */
+	public function getValue() {
+		return $this->output;
+	}
+
+	/**
+	 * Reset the override state to not overridden.
+	 */
+	public function reset() {
+		$this->isOverriden = false;
+		$this->output = null;
+	}
+
+}

--- a/src/Property/PropertyTree.php
+++ b/src/Property/PropertyTree.php
@@ -64,6 +64,22 @@ class PropertyTree {
 	}
 
 	/**
+	 * Check whether a value exists in the raw config tree.
+	 * @return bool whether the property chain has a value set
+	 */
+	public function existsRaw() {
+		return static::existsInTree($this->configRaw, static::unnestArray(func_get_args()));
+	}
+
+	/**
+	 * Check whether a value is exists in the processed config tree.
+	 * @return bool whether the property chain has a value set
+	 */
+	public function exists() {
+		return static::existsInTree($this->config, static::unnestArray(func_get_args()));
+	}
+
+	/**
 	 * Process a property value, rendering twig templates.
 	 * @param  mixed $value raw value
 	 * @param  array $chain property chain leading up to this value for context
@@ -352,6 +368,23 @@ class PropertyTree {
 			}
 		}
 		return $value;
+	}
+
+	/**
+	 * Check whether a value exists at the provided chain.
+	 * @param  array  $tree  multidimensional array
+	 * @param  array  $chain property chain
+	 * @return bool        whether a value exists at the given property chain
+	 */
+	public static function existsInTree(array $tree, array $chain = []) {
+		foreach ($chain as $key) {
+			if (is_array($tree) && array_key_exists($key, $tree)) {
+				$tree = $tree[$key];
+			} else {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	/**

--- a/src/Property/PropertyTree.php
+++ b/src/Property/PropertyTree.php
@@ -14,7 +14,6 @@ class PropertyTree {
 	const PROP_VARS = 'vars'; // twig property to reference vars set in the meta property
 	const PROP_ASCEND = 'parent'; // twig pseudo property to ascend up one level in the property chain
 	const PROP_DEFAULT = 'default'; // config property to provide user defaults
-	const PROP_NAME = 'name'; // config property corresponding to key for assoc arrays that contain only assoc arrays
 	const PROP_CHAIN = 'prop'; // twig property to get the property chain
 
 	protected $twig;

--- a/src/Property/PropertyTree.php
+++ b/src/Property/PropertyTree.php
@@ -19,7 +19,7 @@ class PropertyTree {
 	protected $twig;
 	protected $configRaw = []; // raw config as entered
 	protected $config = []; // config processed with defaults
-	protected $defaults = []; // handler-defined defaults
+	protected $defaults = []; // handler-defined defaults - keyed on handler-identifier
 	protected $userDefaults = []; // user-defined defaults
 
 	public function __construct(Twig_Environment $twig) {
@@ -84,6 +84,7 @@ class PropertyTree {
 			array_walk($value, function(&$item, $key) use ($chain) {
 				$item = $this->processValue($item, array_merge($chain, [$key]));
 			});
+		// strings may have twig template components inside
 		} else if (is_string($value)) {
 			// remove last item of the context chain so that "this" actually refers to the parent of this property
 			$siblingChain = array_slice($chain, 0, -1);

--- a/src/Property/PropertyTree.php
+++ b/src/Property/PropertyTree.php
@@ -33,12 +33,16 @@ class PropertyTree {
 	 * @param  mixed $value  the value to set
 	 */
 	public function set() {
+		// start by getting all args
 		$chain = func_get_args();
+		// value is always the last arg
 		$value = array_pop($chain);
+		// chain may be provided as a single array arg
 		$chain = static::unnestArray($chain);
 		// set the raw values
 		static::setInTree($this->configRaw, $chain, $value);
-		$this->processDefaults($chain);
+		// re-process defaults for the entire top-level property
+		$this->processDefaults(array_slice($chain, 0, 1));
 	}
 
 	/**
@@ -353,7 +357,7 @@ class PropertyTree {
 
 	/**
 	 * Set a value in a multidimensional array at the corresponding property chain.
-	 * @param array  &$tree multidimensial array
+	 * @param array  &$tree multidimensional array
 	 * @param array  $chain property chain
 	 * @param mixed  $value value to set
 	 */

--- a/src/Property/PropertyTree.php
+++ b/src/Property/PropertyTree.php
@@ -1,0 +1,418 @@
+<?php
+
+namespace OomphInc\WASP\Property;
+
+use Twig_Environment;
+use OomphInc\WASP\Wasp;
+use RuntimeException;
+
+class PropertyTree {
+
+	const PROP_SELF = 'this'; // twig property to refer to itself (for self-referential user defaults)
+	const PROP_SIBLINGS = 'this'; // twig property to reference sibling properties
+	const PROP_ROOT = 'top'; // twig property to reference the root config
+	const PROP_VARS = 'vars'; // twig property to reference vars set in the meta property
+	const PROP_ASCEND = 'parent'; // twig pseudo property to ascend up one level in the property chain
+	const PROP_DEFAULT = 'default'; // config property to provide user defaults
+	const PROP_NAME = 'name'; // config property corresponding to key for assoc arrays that contain only assoc arrays
+
+	protected $twig;
+	protected $configRaw = []; // raw config as entered
+	protected $config = []; // config processed with defaults
+	protected $defaults = []; // handler-defined defaults
+	protected $userDefaults = []; // user-defined defaults
+
+	public function __construct(Twig_Environment $twig) {
+		$this->setTwig($twig);
+	}
+
+	/**
+	 * Set a property.
+	 * @param string|array [$property...] property chain
+	 * @param  mixed $value  the value to set
+	 */
+	public function set() {
+		$chain = func_get_args();
+		$value = array_pop($chain);
+		$chain = static::unnestArray($chain);
+		// set the raw values
+		static::setInTree($this->configRaw, $chain, $value);
+		$this->processDefaults($chain);
+	}
+
+	/**
+	 * Get the raw value at the given property chain, if set.
+	 * @param  string|array [$property...] property name
+	 * @return mixed            config value, if set
+	 */
+	public function getRaw() {
+		return static::getFromTree($this->configRaw, static::unnestArray(func_get_args()));
+	}
+
+	/**
+	 * Get the processed value at the given property chain, if set.
+	 * @param  string|array [$property...] property name
+	 * @return mixed            processed config value, if set
+	 */
+	public function get() {
+		$chain = static::unnestArray(func_get_args());
+		return $this->processValue(static::getFromTree($this->config, $chain), $chain);
+	}
+
+	/**
+	 * Process a property value, rendering twig templates.
+	 * @param  mixed $value raw value
+	 * @param  array $chain property chain leading up to this value for context
+	 * @return mixed        processed value
+	 */
+	public function processValue($value, $chain = []) {
+		// store the chains we are currently processing to detect circular references
+		static $processing = [];
+		static $circularReference = null;
+		$serializedChain = serialize($chain);
+		// check for circular references
+		if (isset($processing[$serializedChain])) {
+			// we cannot throw an error here because it would bubble up through a __toString, which is illegal
+			// instead, we make a note, bail early, and throw at the end
+			$circularReference = $chain;
+			return $value;
+		}
+		$processing[$serializedChain] = true;
+
+		// recursively process contents of array
+		if (is_array($value)) {
+			array_walk($value, function(&$item, $key) use ($chain) {
+				$item = $this->processValue($item, array_merge($chain, [$key]));
+			});
+		} else if (is_string($value)) {
+			// remove last item of the context chain so that "this" actually refers to the parent of this property
+			$siblingChain = array_slice($chain, 0, -1);
+			// process twig template values
+			$value = $this->getTwig()->createTemplate($value)->render([
+				static::PROP_SIBLINGS => new PropertyChain($this, $siblingChain, static::PROP_ASCEND),
+			] + $this->createGlobalContext());
+
+			// look for a user-defined default property, by replacing this prop's parent's name with "default"
+			$userDefaultChain = $chain;
+			array_splice($userDefaultChain, -2, 1, static::PROP_DEFAULT);
+
+			// does a user value exist? if so, check to see if it is self-referential
+			if (is_string($userDefault = $this->getUserDefault($userDefaultChain))) {
+				// starting twig context
+				$context = $this->createGlobalContext();
+
+				// is siblings prop named something different than self prop?
+				if (static::PROP_SIBLINGS !== static::PROP_SELF) {
+					$context += [
+						static::PROP_SIBLINGS => new PropertyChain($this, $siblingChain, static::PROP_ASCEND),
+						static::PROP_SELF => new PropertyChain($this, $siblingChain),
+					];
+				} else {
+					$context[static::PROP_SIBLINGS] = new PropertyChain($this, $siblingChain, static::PROP_ASCEND);
+				}
+
+				// when referencing itself, the twig value should be the current processed value we have
+				$context[static::PROP_SELF]->setShortCircuitValue($siblingChain, $value);
+				$newValue = $this->getTwig()->createTemplate($userDefault)->render($context);
+
+				// did we reference ourself?
+				if (in_array($siblingChain, $context[static::PROP_SELF]->getHistory(), true)) {
+					// use this value
+					$value = $newValue;
+				}
+			}
+		}
+
+		// we are done processing this chain
+		unset($processing[$serializedChain]);
+		// are we done recursing?
+		if (!count($processing)) {
+			// did we have a circular reference?
+			if ($circularReference) {
+				throw new RuntimeException('Circular reference in config property: ' . implode('.', $circularReference));
+			}
+			$circularReference = null;
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Context items that are provided for all twig rendering.
+	 * @return array twig context array
+	 */
+	protected function createGlobalContext() {
+		return [
+			static::PROP_ROOT => new PropertyChain($this),
+			static::PROP_VARS => new PropertyChain($this, [Wasp::META_PROPERTY, static::PROP_VARS]),
+		];
+	}
+
+	/**
+	 * Set the default value for a property.
+	 * @param string|array [$property...] property chain
+	 * @param  mixed $value  the default value to set
+	 */
+	public function setDefault() {
+		$chain = func_get_args();
+		$value = array_pop($chain);
+		$chain = static::unnestArray($chain);
+		static::setInTree($this->defaults, $chain, $value);
+		// re-process defaults for the entire top-level property
+		$this->processDefaults(array_slice($chain, 0, 1));
+	}
+
+	/**
+	 * Get the default at the given property chain, if set.
+	 * @param  string|array [$property...] property name
+	 * @return mixed            default value, if set
+	 */
+	public function getDefault() {
+		return static::getFromTree($this->defaults, static::unnestArray(func_get_args()));
+	}
+
+	/**
+	 * Get the user default at the given property chain, if set.
+	 * @param  string|array [$property...] property name
+	 * @return mixed            default value, if set
+	 */
+	public function getUserDefault() {
+		return static::getFromTree($this->userDefaults, static::unnestArray(func_get_args()));
+	}
+
+	/**
+	 * Pluck out user defaults and place in the user defaults array.
+	 * @param  mixed $value value to pluck from
+	 * @param  array $chain property chain
+	 * @return mixed        value with any defaults removed
+	 */
+	protected function pluckUserDefaults($value, $chain) {
+		if (is_array($value)) {
+			// pluck out user defaults
+			if (static::isAssocArray($value) && isset($value[static::PROP_DEFAULT]) && static::hasOnlyAssocArrays($value)) {
+				// set user default
+				static::setInTree($this->userDefaults, array_merge($chain, [static::PROP_DEFAULT]), $value[static::PROP_DEFAULT]);
+				unset($value[static::PROP_DEFAULT]);
+			}
+			// recursively pluck for all values
+			array_walk($value, function(&$item, $key) use ($chain) {
+				$item = $this->pluckUserDefaults($item, array_merge($chain, [$key]));
+			});
+		}
+		return $value;
+	}
+
+	/**
+	 * Process and save the raw values against the defaults for the given chain.
+	 * @param  array $chain property chain
+	 */
+	public function processDefaults($chain) {
+		$processed = $this->getRaw($chain);
+		// pluck out user defaults
+		$processed = $this->pluckUserDefaults($processed, $chain);
+		// user defaults can have self-referential properties, but remove them as they are handled elsewhere
+		$userDefaults = $this->removeSelfReferentialTemplates($this->getUserDefault($chain));
+		// fill in defaults
+		static::applyDefaults($processed, $userDefaults, $this->getDefault($chain));
+		// set the processed values
+		static::setInTree($this->config, $chain, $processed);
+	}
+
+	/**
+	 * Remove self-referential templates from defaults, as these should not be filled in as actual values.
+	 * @param  mixed $value value to remove templates from
+	 * @return mixed value but without self-referential templates
+	 */
+	protected function removeSelfReferentialTemplates($value) {
+		if (!static::isAssocArray($value)) {
+			return $value;
+		}
+
+		// look for templates to remove
+		foreach ($value as $key => $item) {
+			// rescurse assoc array
+			if (static::isAssocArray($item)) {
+				$value[$key] = $this->removeSelfReferentialTemplates($item);
+			// check strings only
+			} else if (is_string($item)) {
+				$test = new PropertyChain($this);
+				$test->setShortCircuitValue([], '');
+				$this->getTwig()->createTemplate($item)->render([static::PROP_SELF => $test]);
+				// was "this" accessed?
+				if (in_array([], $test->getHistory(), true)) {
+					unset($value[$key]);
+				}
+			}
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Set the Twig environment object.
+	 * @param Twig_Environment $twig twig environment
+	 */
+	public function setTwig(Twig_Environment $twig) {
+		$this->twig = $twig;
+	}
+
+	/**
+	 * Get the Twig environment.
+	 * @return Twig_Environment
+	 */
+	public function getTwig() {
+		return $this->twig;
+	}
+
+	/**
+	 * Determine if an array is assoc or not.
+	 * @param  mixed   $array value to test
+	 * @return boolean        true if assoc, false if not
+	 */
+	public static function isAssocArray($array, $countEmpty = false) {
+		if (!is_array($array)) {
+			return false;
+		}
+
+		// do we want to count an empty array as assoc?
+		if (!count($array) && $countEmpty) {
+			return true;
+		}
+
+		$i = 0;
+		foreach ($array as $key => $value) {
+			if ($key !== $i++) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if an array contains only assoc arrays.
+	 * @param  array   $array array to test
+	 * @return boolean        true if all items are assoc arrays
+	 */
+	public static function hasOnlyAssocArrays(array $array) {
+		foreach ($array as $value) {
+			if (!static::isAssocArray($value)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Get the value in the multidimensional array (tree) corresponding to the given property chain, if set.
+	 * @param  array  $tree  multidimensional array
+	 * @param  array  $chain property chain
+	 * @return mixed       value, if set
+	 */
+	public static function getFromTree(array $tree, array $chain = []) {
+		$value = $tree;
+		foreach ($chain as $key) {
+			if (is_array($value) && isset($value[$key])) {
+				$value = $value[$key];
+			} else {
+				return;
+			}
+		}
+		return $value;
+	}
+
+	/**
+	 * Set a value in a multidimensional array at the corresponding property chain.
+	 * @param array  &$tree multidimensial array
+	 * @param array  $chain property chain
+	 * @param mixed  $value value to set
+	 */
+	public static function setInTree(array &$tree, array $chain, $value) {
+		if (count($chain) === 0) {
+			$tree = $value;
+			return;
+		}
+
+		$key = array_shift($chain);
+
+		if (count($chain) === 0) {
+			$tree[$key] = $value;
+		} else {
+			if (!isset($tree[$key]) || !is_array($tree[$key])) {
+				$tree[$key] = [];
+			}
+			static::setInTree($tree[$key], $chain, $value);
+		}
+	}
+
+	/**
+	 * If the array has only one item and it is also an array, return that item, otherwise the array.
+	 * @param  array  $array  possibly nested array
+	 * @return array        possibly unnested array
+	 */
+	public static function unnestArray(array $array) {
+		return count($array) === 1 && is_array($array[0]) ? $array[0] : $array;
+	}
+
+	/**
+	 * Apply defaults to a given value.
+	 * @param  mixed &$value value to apply defaults to
+	 * @param  array [$defaults...] arrays of defaults to apply, in order of precedence
+	 */
+	public static function applyDefaults(&$value) {
+		// we can only apply defaults on assoc arrays
+		if (!static::isAssocArray($value)) {
+			return;
+		}
+
+		// grab the defaults
+		$defaults = array_slice(func_get_args(), 1);
+		if (!count($defaults)) {
+			return;
+		}
+
+		// is this an assoc array with only assoc arrays?
+		if (static::hasOnlyAssocArrays($value)) {
+			// look for ['default' => []] arrays within
+			$defaultsArrs = [];
+			foreach ($defaults as $default) {
+				if (static::isAssocArray($default) // must be an assoc array
+					&& count($default) === 1 // can only have one item
+					&& isset($default[static::PROP_DEFAULT]) // that item's key must be "default"
+					&& static::isAssocArray($default[static::PROP_DEFAULT], true) // that item must also be an assoc or empty array
+				) {
+					$defaultsArrs[] = $default[static::PROP_DEFAULT];
+				}
+			}
+
+			// do we have any defaults arrays?
+			if (count($defaultsArrs)) {
+				array_walk($value, function(&$item, $key) use ($defaultsArrs) {
+					// add a defaults array to fill in "name" property, using the assoc key
+					$defaultsArrs[] = [static::PROP_NAME => $key];
+					call_user_func_array([static::class, 'applyDefaults'], array_merge([&$item], $defaultsArrs));
+				});
+				// we are done with this one!
+				return;
+			}
+		}
+
+		// fill in defaults
+		foreach ($defaults as $default) {
+			// default must be an assoc array
+			if (!static::isAssocArray($default)) {
+				continue;
+			}
+			// cycle through and apply defaults
+			foreach ($default as $key => $defaultValue) {
+				// if the key isn't set, take the whole default value
+				if (!isset($value[$key])) {
+					$value[$key] = $defaultValue;
+				// otherwise if value and default are both assoc arrays, recursively merge in values
+				} else if (static::isAssocArray($value[$key]) && static::isAssocArray($defaultValue)) {
+					static::applyDefaults($value[$key], $defaultValue);
+				}
+			}
+		}
+	}
+
+}

--- a/src/Wasp.php
+++ b/src/Wasp.php
@@ -12,6 +12,8 @@ use OomphInc\WASP\Input\PartialInputDefinition;
 use Symfony\Component\Console\ConsoleEvents;
 use OomphInc\WASP\Event\Events;
 use Closure;
+use Twig_Environment;
+use Twig_Loader_Array;
 
 class Wasp {
 
@@ -85,6 +87,7 @@ class Wasp {
 			'filesystem' => __NAMESPACE__ . '\FileSystem\FileSystemInterface',
 			'stdin' => __NAMESPACE__ . '\Input\StdInInterface',
 			'linter' => __NAMESPACE__ . '\Linter\LinterInterface',
+			'twig' => 'Twig_Environment',
 		];
 	}
 
@@ -111,6 +114,12 @@ class Wasp {
 			},
 			'transformer' => function() {
 				return new YamlTransformer($this->getServiceVar('yaml'), $this->getService('dispatcher'), $this->getService('logger'));
+			},
+			'propertyTree' => function() {
+				return new Property\PropertyTree($this->getService('twig'));
+			},
+			'twig' => function() {
+				return new Twig_Environment(new Twig_Loader_Array(), ['autoescape' => false]);
 			},
 		];
 	}

--- a/src/Wasp.php
+++ b/src/Wasp.php
@@ -113,7 +113,7 @@ class Wasp {
 				return new Linter\PhpLinter();
 			},
 			'transformer' => function() {
-				return new YamlTransformer($this->getServiceVar('yaml'), $this->getService('dispatcher'), $this->getService('logger'));
+				return new YamlTransformer($this->getServiceVar('yaml'), $this->getService('dispatcher'), $this->getService('logger'), $this->getService('propertyTree'));
 			},
 			'propertyTree' => function() {
 				return new Property\PropertyTree($this->getService('twig'));

--- a/src/YamlTransformer.php
+++ b/src/YamlTransformer.php
@@ -95,7 +95,6 @@ class YamlTransformer {
 	 * Remove the transform handler matching the given property and identifier.
 	 * @param  string $property   YAML property
 	 * @param  string $identifier handler indentifier
-	 * @param  bool   $removeDefaults  whether to remove any associated defaults
 	 */
 	public function removeHandler($property, $identifier) {
 		unset($this->handlers[$property][$identifier]);

--- a/src/YamlTransformer.php
+++ b/src/YamlTransformer.php
@@ -11,22 +11,26 @@ use OomphInc\WASP\Event\Events;
 use OomphInc\WASP\Event\ValueEvent;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use RuntimeException;
+use InvalidArgumentException;
+use OomphInc\WASP\Handler\HandlerInterface;
 
 class YamlTransformer {
 
 	protected $yamlString;
-	protected $yaml;
 	protected $handlers = [];
+	protected $defaultsCallables = [];
 	protected $classes = [];
 	protected $vars = [];
 	protected $dispatcher;
 	protected $logger;
+	protected $propertyTree;
 	public $outputExpression;
 
 	/**
 	 * @param string $yaml_string contents of YAML configuration
 	 */
-	public function __construct($yamlString, $dispatcher, $logger) {
+	public function __construct($yamlString, $dispatcher, $logger, $propertyTree) {
+		$this->propertyTree = $propertyTree;
 		$this->setYaml($yamlString);
 		$this->dispatcher = $dispatcher;
 		$this->logger = $logger;
@@ -45,10 +49,11 @@ class YamlTransformer {
 	public function setYaml($yamlString) {
 		$this->yamlString = $yamlString;
 		// try to parse the string (will throw an exception on parse error, caught by the application)
-		$this->yaml = Yaml::parse($yamlString);
-		if (!is_array($this->yaml)) {
+		$yaml = Yaml::parse($yamlString);
+		if (!is_array($yaml)) {
 			throw new RuntimeException('Invalid YAML file');
 		}
+		$this->propertyTree->set($yaml);
 	}
 
 	/**
@@ -56,32 +61,45 @@ class YamlTransformer {
 	 * @param string   $property   property to handle
 	 * @param string   $identifier unique identifier for this handler
 	 * @param callable $handler    the handler that will be invoked when the property is encountered
+	 * @param callable [$defaults]   callable that provides default values when executed
 	 */
-	public function setHandler($property, $identifier, callable $handler) {
+	public function setHandler($property, $identifier = null, callable $handler = null, callable $defaults = null) {
+		// allow a HandlerInterface object as the only arg
+		if ($property instanceof HandlerInterface) {
+			$handler = $property;
+			foreach ((array) $handler->getSubscribedProperties() as $property) {
+				$this->setHandler($property, $handler->getIdentifier($property), [$handler, 'handle'], [$handler, 'getDefaults']);
+			}
+			return;
+		}
+
+		if (!is_string($property)) {
+			throw new InvalidArgumentException('Handler property must be a string!');
+		}
+
+		if (!is_string($identifier)) {
+			throw new InvalidArgumentException('Handler identifier must be a string!');
+		}
+
+		if (!is_callable($handler)) {
+			throw new InvalidArgumentException('Not a valid callable for handler!');
+		}
+
 		$this->handlers[$property][$identifier] = $handler;
+		if (is_callable($defaults)) {
+			$this->defaultsCallables[$property][$identifier] = $defaults;
+		}
 	}
 
 	/**
 	 * Remove the transform handler matching the given property and identifier.
 	 * @param  string $property   YAML property
 	 * @param  string $identifier handler indentifier
+	 * @param  bool   $removeDefaults  whether to remove any associated defaults
 	 */
 	public function removeHandler($property, $identifier) {
 		unset($this->handlers[$property][$identifier]);
-	}
-
-	/**
-	 * Set handlers based on the public methods of the given class.
-	 * Each method should be named after the top-level property it will handle.
-	 * @param  string|object  $class     class name (for static methods) or instantiated object (for non static)
-	 * @param  string  $prefix           prefix for the handler identifier
-	 * @param  boolean $convertFromCamel whether to convert the method names from camelCase to snake_case
-	 */
-	public function importHandlersFromClass($class, $prefix, $convertFromCamel = true) {
-		foreach (get_class_methods($class) as $method) {
-			$handler = $convertFromCamel ? strtolower(preg_replace('/[A-Z]/', '_$0', $method)) : $method;
-			$this->setHandler($handler, $prefix . $handler, [$class, $method]);
-		}
+		unset($this->defaultsCallables[$property][$identifier]);
 	}
 
 	/**
@@ -119,28 +137,20 @@ class YamlTransformer {
 
 	/**
 	 * Get the parsed YAML config for the given property chain, if set.
+	 * This is a convenience wrapper around the PropertyTree::get method.
 	 * @param  string [$property...] property name
 	 * @return mixed            config value, if set
 	 */
 	public function getProperty() {
-		$value = $this->yaml;
-		foreach (func_get_args() as $key) {
-			if (is_array($value) && isset($value[$key])) {
-				$value = $value[$key];
-			} else {
-				return;
-			}
-		}
-		return $value;
+		return $this->propertyTree->get(func_get_args());
 	}
 
 	/**
-	 * Set the value for a top-level property within the YAML config.
-	 * @param string $property property name
-	 * @param mixed  $value    data
+	 * Get the property tree object.
+	 * @return PropertyTree      property tree object
 	 */
-	public function setProperty($property, $value) {
-		$this->yaml[$property] = $value;
+	public function getPropertyTree() {
+		return $this->propertyTree;
 	}
 
 	/**
@@ -190,15 +200,30 @@ class YamlTransformer {
 	public function execute(array $disabledHandlers = []) {
 		$this->dispatcher->dispatch(Events::PRE_TRANSFORM);
 
-		foreach ($this->yaml as $property => $data) {
-			if (isset($this->handlers[$property])) {
+		// only iterate on top-level properties that were explicitly set
+		foreach (array_keys($this->propertyTree->getRaw()) as $property) {
+			// do we have any handlers?
+			if (!empty($this->handlers[$property])) {
+				// process handler defaults
+				if (!empty($this->defaultsCallables[$property])) {
+					foreach ($this->defaultsCallables[$property] as $identifier => $callable) {
+						// are we skipping this handler?
+						if (in_array($identifier, $disabledHandlers, true)) {
+							continue;
+						}
+						$this->propertyTree->setDefault($identifier, $property, call_user_func($callable, $property));
+					}
+				}
+
+				// execute each handler
 				foreach ($this->handlers[$property] as $identifier => $handler) {
+					// skip handler?
 					if (in_array($identifier, $disabledHandlers, true)) {
 						$this->logger->info("Skipping handler '$identifier'");
 						continue;
 					}
 					$this->logger->info("Executing handler '$identifier'");
-					call_user_func($handler, $this, $data, $property);
+					call_user_func($handler, $this, $this->propertyTree->get($property), $property);
 				}
 			} else {
 				$this->logger->notice("No handlers for property '$property'");


### PR DESCRIPTION
## Defaults Handling
Resolves config property tree against user defaults (plucked out of the property tree itself - see below) and defaults provided by handlers. Handlers can supply an optional defaults callback upon registration, which should return an array of default values for the corresponding property when called. Handler defaults are applied in the order in which they were registered, thus earlier defaults will take precedence (and this can be controlled via event priority values). There is a new `HandlerInterface` (and a couple of additional abstract classes) that can be used as a way to pass all required items as one convenient object.

## Property Tree
There is a new `PropertyTree` object that handles the raw config and processing that against the defaults, including resolution of properties that contain twig templates. The config and defaults can be updated at any time and will automatically reprocess accordingly.

## Twig Templates
Twig templates have access to the following properties:
* `this` which refers to the property's direct parent to reference its sibling properties
* `parent` which is a pseudo property that can be used with the `this` property to ascend further up the property tree (e.g. `this.parent.parent.property`)
* `top` which refers to the top-level config
* `vars` which refers to `top.wasp.vars` as a convenient way to set and use config-wide variables
* `prop` which is an array of the current property chain, with the current property being index 0 and working backwards
* `env` which is a simple property that is an object with only a `set()` method (which set public properties, which can be accessed directly) that is shared amongst a template and any referenced templates, so they can communicate with each other during rendering
* `output` which is a property that can be used to override the rendered value of the template, mostly useful to produce a non-string value

## PropertyChain Magic
`this`, `top`, and `vars` are `PropertyChain` objects, which are instantiated with a starting property chain and add to the chain (or in the case of `parent`, remove from the chain) anytime any property is accessed. It uses the `__get` method to add to the chain and then returns itself to keep adding to the chain for additional property accesses, until twig retrieves the value by typecasting to a string, thereby triggering the `__toString` method. At that point, the value from the property tree respective to the current chain is returned and the chain is reset to its starting chain for subsequent uses in that template. In order to access a value that can't/shouldn't be cast to a string, the property chain should end with `.getValue()`, e.g. `{{ this.parent.getValue() | join(', ') }}`, or as a shortcut, `{{ this.parent() | join(', ') }}` which triggers the `__call()` method and essentially fires `__get` and `getValue` at the same time.

## User Defaults
User Defaults can be supplied in the config file for any properties that are assoc arrays containing only assoc arrays. The outer assoc array should have an element with the key `default` which is an assoc array that will be applied against the other assoc arrays. For example:

```yml
post_types:
  default:
    post_type: wasp_{{ this }}
    show_ui: false

  events:
    label: Events
    post_type: events
```

User defaults also allow self-referential templates (templates referring to the `this` keyword by itself) and resolves said template using the rendered value from the respective property of the fellow assoc arrays. This is useful for things like prefixing/namespacing.

This example would resolve to:
```yml
post_types:
  events:
    label: Events
    post_type: wasp_events
    show_ui: false
```

P.S. providing the `post_type` property would be optional, because the `post_types` handler could provide the following default:
```yml
post_types:
  default:
    post_type: {{ prop[1] }}
```
which would fill the default value as the parent key for that assoc array!